### PR TITLE
Add financial survey and risk enum support

### DIFF
--- a/frontend/lib/enums/risk.ts
+++ b/frontend/lib/enums/risk.ts
@@ -1,0 +1,15 @@
+export enum Risk {
+  Low = 1,
+  Medium,
+  High,
+  Critical,
+  Unknown,
+}
+
+export const riskLabels: Record<string, string> = {
+  1: 'Low',
+  2: 'Medium',
+  3: 'High',
+  4: 'Critical',
+  5: 'Unknown',
+};

--- a/frontend/lib/schemas/profileSchema.ts
+++ b/frontend/lib/schemas/profileSchema.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import { PersonalityType } from '@/lib/enums/personalityTypes';
+import { Risk } from '@/lib/enums/risk';
 
 const certificateEntrySchema = z.object({
   name: z.string().min(1, 'Certificate name is required'),
@@ -33,6 +34,15 @@ const languageEntrySchema = z.object({
   level: z.string().optional(),
 });
 
+const financialSurveySchema = z.object({
+  currentSalary: z.number().optional(),
+  desiredSalary: z.number().optional(),
+  hasLoans: z.boolean().default(false),
+  loanDetails: z.string().optional(),
+  riskAppetite: z.nativeEnum(Risk).default(Risk.Unknown),
+  willingToRelocate: z.boolean().default(false),
+});
+
 const baseProfileSchema = z.object({
   firstName: z.string().min(1, 'First name is required'),
   lastName: z.string().min(1, 'Last name is required'),
@@ -47,6 +57,7 @@ const baseProfileSchema = z.object({
   additionalInformation: z.string().optional(),
   aboutMe: z.string().optional(),
   personalityType: z.nativeEnum(PersonalityType),
+  financialSurvey: financialSurveySchema.optional(),
 });
 
 export const createProfileSchema = baseProfileSchema;

--- a/frontend/lib/types/profile.ts
+++ b/frontend/lib/types/profile.ts
@@ -50,6 +50,23 @@ export enum PersonalityType {
   Unknown,
 }
 
+export enum Risk {
+  Low = 1,
+  Medium,
+  High,
+  Critical,
+  Unknown,
+}
+
+export type FinancialSurvey = {
+  currentSalary?: number;
+  desiredSalary?: number;
+  hasLoans?: boolean;
+  loanDetails?: string;
+  riskAppetite: Risk;
+  willingToRelocate?: boolean;
+};
+
 export type UserProfile = {
   firstName: string;
   lastName: string;
@@ -64,4 +81,5 @@ export type UserProfile = {
   additionalInformation?: string;
   aboutMe?: string;
   personalityType: PersonalityType;
+  financialSurvey?: FinancialSurvey;
 };


### PR DESCRIPTION
## Summary
- define `Risk` enum with labels
- extend user profile types with financial survey
- include financial survey validation in profile schema

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68408a21e4bc8328845652ea97671f5f