### PR TITLE
Add Cypress configuration and initial auth tests

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -34,3 +34,20 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+
+## Cypress Tests
+
+End-to-end tests are written with [Cypress](https://www.cypress.io). Test
+specifications live in `cypress/e2e`:
+
+- `login.cy.ts` verifies the sign-in flow
+- `register.cy.ts` verifies the sign-up flow
+
+Start the development server and run the tests with:
+
+```bash
+npm run dev &
+npm run cy:open    # open the Cypress GUI
+# or
+npm run cy:run     # run all tests headlessly
+```

--- a/frontend/cypress.config.ts
+++ b/frontend/cypress.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'cypress';
+
+export default defineConfig({
+  e2e: {
+    baseUrl: 'http://localhost:3000',
+    supportFile: 'cypress/support/e2e.ts',
+    specPattern: 'cypress/e2e/**/*.cy.{js,ts}',
+  },
+});

--- a/frontend/cypress/e2e/login.cy.ts
+++ b/frontend/cypress/e2e/login.cy.ts
@@ -4,10 +4,19 @@ describe('Login Page', () => {
   });
 
   it('should allow a user to log in', () => {
-    cy.intercept('POST', '/login').as('login');
+    cy.intercept('POST', '/login', {
+      statusCode: 200,
+      body: { token: 'testtoken' },
+    }).as('login');
+
     cy.get('input[placeholder="joedoe@gmail.com.."]').type('user@example.com');
     cy.get('input[placeholder="Password"]').type('password');
     cy.get('button[type="submit"]').click();
+
     cy.wait('@login');
+    cy.location('pathname').should('eq', '/');
+    cy.window().then((win) => {
+      expect(win.localStorage.getItem('token')).to.eq('testtoken');
+    });
   });
 });

--- a/frontend/cypress/e2e/login.cy.ts
+++ b/frontend/cypress/e2e/login.cy.ts
@@ -1,0 +1,13 @@
+describe('Login Page', () => {
+  beforeEach(() => {
+    cy.visit('/sign-in');
+  });
+
+  it('should allow a user to log in', () => {
+    cy.intercept('POST', '/login').as('login');
+    cy.get('input[placeholder="joedoe@gmail.com.."]').type('user@example.com');
+    cy.get('input[placeholder="Password"]').type('password');
+    cy.get('button[type="submit"]').click();
+    cy.wait('@login');
+  });
+});

--- a/frontend/cypress/e2e/register.cy.ts
+++ b/frontend/cypress/e2e/register.cy.ts
@@ -1,0 +1,15 @@
+describe('Register Page', () => {
+  beforeEach(() => {
+    cy.visit('/sign-up');
+  });
+
+  it('should allow a user to register', () => {
+    cy.intercept('POST', '/api/register').as('register');
+    cy.get('input[placeholder="Joe Doe.."]').type('Test User');
+    cy.get('input[placeholder="joedoe@gmail.com.."]').type('newuser@example.com');
+    cy.get('input[placeholder="Password"]').first().type('password');
+    cy.get('input[placeholder="Confirm Password"]').type('password');
+    cy.get('button[type="submit"]').click();
+    cy.wait('@register');
+  });
+});

--- a/frontend/cypress/e2e/register.cy.ts
+++ b/frontend/cypress/e2e/register.cy.ts
@@ -4,12 +4,18 @@ describe('Register Page', () => {
   });
 
   it('should allow a user to register', () => {
-    cy.intercept('POST', '/api/register').as('register');
+    cy.intercept('POST', '/api/register', {
+      statusCode: 200,
+      body: { success: true },
+    }).as('register');
+
     cy.get('input[placeholder="Joe Doe.."]').type('Test User');
     cy.get('input[placeholder="joedoe@gmail.com.."]').type('newuser@example.com');
     cy.get('input[placeholder="Password"]').first().type('password');
     cy.get('input[placeholder="Confirm Password"]').type('password');
     cy.get('button[type="submit"]').click();
+
     cy.wait('@register');
+    cy.location('pathname').should('include', '/sign-in');
   });
 });

--- a/frontend/cypress/support/commands.ts
+++ b/frontend/cypress/support/commands.ts
@@ -1,0 +1,2 @@
+// Add custom Cypress commands here
+

--- a/frontend/cypress/support/e2e.ts
+++ b/frontend/cypress/support/e2e.ts
@@ -1,0 +1,6 @@
+// Import commands.js using ES2015 syntax:
+import './commands';
+
+// Alternatively you can use CommonJS syntax:
+// require('./commands')
+

--- a/frontend/cypress/tsconfig.json
+++ b/frontend/cypress/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "types": ["cypress"],
+    "allowJs": true
+  },
+  "include": ["../cypress/**/*.ts", "../cypress/**/*.js"]
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,9 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "format": "prettier --write ."
+    "format": "prettier --write .",
+    "cy:open": "cypress open",
+    "cy:run": "cypress run"
   },
   "dependencies": {
     "@gsap/react": "^2.1.2",
@@ -79,7 +81,8 @@
     "prettier": "^3.5.3",
     "prettier-plugin-tailwindcss": "^0.6.11",
     "tailwindcss": "^4",
-    "typescript": "^5"
+    "typescript": "^5",
+    "cypress": "^13.7.0"
   },
   "overrides": {
     "react-is": "^19.0.0-rc-69d4b800-20241021"


### PR DESCRIPTION
## Summary
- set up Cypress in the frontend project
- add scripts and dependency for Cypress
- create basic login and registration e2e tests

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run cy:run` *(fails: cypress not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843f5e5fdb0832892b476036b826efe