### PR TITLE
Fix WebAPI Dockerfile build

### DIFF
--- a/VocareWebAPI/Dockerfile
+++ b/VocareWebAPI/Dockerfile
@@ -3,11 +3,12 @@ FROM mcr.microsoft.com/dotnet/sdk:9.0 AS build
 WORKDIR /src
 
 # 1.1) Przywróć pakiety tylko dla projektu API
-COPY VocareWebAPI/VocareWebAPI.csproj ./VocareWebAPI/
-RUN dotnet restore
+COPY VocareWebAPI/VocareWebAPI.csproj VocareWebAPI/
+RUN dotnet restore "VocareWebAPI/VocareWebAPI.csproj"
 
 # 1.2) Skopiuj resztę plików i opublikuj
-COPY . ./
+COPY VocareWebAPI/ VocareWebAPI/
+WORKDIR /src/VocareWebAPI
 RUN dotnet publish -c Release -o /app/publish
 
 # 2) ETAP RUNTIME


### PR DESCRIPTION
## Summary
- fix Dockerfile path usage for VocareWebAPI so `dotnet restore` runs correctly

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68440b15cbe4832892060a330cf44536