### PR TITLE
Fix profile state check and cleanup localStorage

### DIFF
--- a/frontend/components/MarketComponents/EmptyStateComponent.tsx
+++ b/frontend/components/MarketComponents/EmptyStateComponent.tsx
@@ -34,9 +34,24 @@ export default function EmptyStateComponent({
   refresh,
 }: EmptyStateComponentProps) {
   const [isConfirmDialogOpen, setIsConfirmDialogOpen] = useState(false);
+  const [isProfileComplete, setIsProfileComplete] = useState(false);
   const flippingURef = useRef<HTMLSpanElement | null>(null);
   const shakeRef = useRef<HTMLSpanElement | null>(null);
   const flowerRef = useRef<HTMLImageElement | null>(null);
+
+  useEffect(() => {
+    const storedProfile = localStorage.getItem('userProfile');
+    if (storedProfile) {
+      try {
+        const parsed = JSON.parse(storedProfile);
+        if (parsed && typeof parsed === 'object') {
+          setIsProfileComplete(true);
+        }
+      } catch {
+        setIsProfileComplete(false);
+      }
+    }
+  }, []);
 
   useEffect(() => {
     if (flippingURef.current) {
@@ -144,20 +159,30 @@ export default function EmptyStateComponent({
               </div>
             </div>
 
-            <CustomButton
-              onClick={() => setIsConfirmDialogOpen(true)}
-              disabled={isLoading}
-              className="group flex h-[56px] cursor-pointer items-center justify-center rounded-full bg-[#915EFF] px-6 text-[clamp(1.1rem,1vw,1.5rem)] font-medium text-white hover:bg-[#7b4ee0] max-md:mt-6 xl:w-[280px]"
-            >
-              <span>{isLoading ? 'Generating...' : 'Generate analysis'}</span>
-              <ArrowRight className="ml-4 scale-125 transition-transform duration-300 group-hover:translate-x-2" />
-            </CustomButton>
+            {isProfileComplete ? (
+              <CustomButton
+                onClick={() => setIsConfirmDialogOpen(true)}
+                disabled={isLoading}
+                className="group flex h-[56px] cursor-pointer items-center justify-center rounded-full bg-[#915EFF] px-6 text-[clamp(1.1rem,1vw,1.5rem)] font-medium text-white hover:bg-[#7b4ee0] max-md:mt-6 xl:w-[280px]"
+              >
+                <span>{isLoading ? 'Generating...' : 'Generate analysis'}</span>
+                <ArrowRight className="ml-4 scale-125 transition-transform duration-300 group-hover:translate-x-2" />
+              </CustomButton>
+            ) : (
+              <Link href="/profile">
+                <CustomButton className="group flex h-[56px] cursor-pointer items-center justify-center rounded-full bg-[#915EFF] px-6 text-[clamp(1.1rem,1vw,1.5rem)] font-medium text-white hover:bg-[#7b4ee0] max-md:mt-6 xl:w-[280px]">
+                  <span>Complete profile</span>
+                  <ArrowRight className="ml-4 scale-125 transition-transform duration-300 group-hover:translate-x-2" />
+                </CustomButton>
+              </Link>
+            )}
           </div>
         </div>
       </div>
 
-      <AlertDialog open={isConfirmDialogOpen} onOpenChange={setIsConfirmDialogOpen}>
-        <AlertDialogContent className="font-poppins mx-auto max-w-md">
+      {isProfileComplete && (
+        <AlertDialog open={isConfirmDialogOpen} onOpenChange={setIsConfirmDialogOpen}>
+          <AlertDialogContent className="font-poppins mx-auto max-w-md">
           <AlertDialogHeader>
             <AlertDialogTitle className="text-center text-xl font-bold">
               Generate market analysis?
@@ -206,6 +231,7 @@ export default function EmptyStateComponent({
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>
+      )}
     </div>
   );
 }

--- a/frontend/components/ProfileFormComponents/ProfileForm.tsx
+++ b/frontend/components/ProfileFormComponents/ProfileForm.tsx
@@ -213,6 +213,7 @@ export default function ProfileForm({
     setLoading(true);
     try {
       await deleteUserProfile();
+      localStorage.removeItem('userProfile');
       toast.success('Profile deleted successfully!');
       router.push('/');
     } catch (err) {

--- a/frontend/lib/auth.ts
+++ b/frontend/lib/auth.ts
@@ -39,5 +39,6 @@ export const loginUser = async ({ email, password }: LoginInput) => {
 
 export const logoutUser = () => {
   localStorage.removeItem('token');
+  localStorage.removeItem('userProfile');
   window.location.href = '/sign-in';
 };


### PR DESCRIPTION
## Summary
- determine profile completion from `userProfile` in `EmptyStateComponent`
- offer 'Complete profile' option when no profile is stored
- display confirmation dialog only if profile exists
- clear `userProfile` on logout and profile deletion

## Testing
- `npm run lint` *(fails: `npm` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68471cb0622c8328aaaa48cfb934d8f7