### PR TITLE
Add WillingToRebrand option

### DIFF
--- a/frontend/app/(root)/steps/StepFive.tsx
+++ b/frontend/app/(root)/steps/StepFive.tsx
@@ -187,6 +187,43 @@ export default function StepFive({
 
       <FormField
         control={form.control}
+        name="willingToRebrand"
+        render={({ field }) => (
+          <FormItem>
+            <FormLabel>Willing to rebrand?</FormLabel>
+            <FormControl>
+              <div className="flex space-x-2">
+                <Button
+                  type="button"
+                  onClick={() => field.onChange(true)}
+                  className={`h-12 flex-1 rounded-lg transition-all ${
+                    field.value === true
+                      ? 'bg-[#915EFF] text-white shadow-[0_2px_4px_rgba(145,94,255,0.5)] dark:hover:bg-[#713ae8]'
+                      : 'border bg-gray-200 text-gray-700 hover:bg-gray-300 dark:bg-[#262626] dark:text-gray-300 dark:hover:bg-gray-400/30'
+                  }`}
+                >
+                  Yes
+                </Button>
+                <Button
+                  type="button"
+                  onClick={() => field.onChange(false)}
+                  className={`h-12 flex-1 rounded-lg transition-all ${
+                    field.value === false
+                      ? 'bg-[#915EFF] text-white shadow-[0_2px_4px_rgba(145,94,255,0.5)] dark:hover:bg-[#713ae8]'
+                      : 'border bg-gray-200 text-gray-700 dark:bg-[#262626] dark:text-gray-300 dark:hover:bg-gray-400/30'
+                  }`}
+                >
+                  No
+                </Button>
+              </div>
+            </FormControl>
+            <FormMessage />
+          </FormItem>
+        )}
+      />
+
+      <FormField
+        control={form.control}
         name="financialSurvey.riskAppetite"
         render={({ field }) => (
           <FormItem>

--- a/frontend/components/ProfileFormComponents/ProfileDeatail.tsx
+++ b/frontend/components/ProfileFormComponents/ProfileDeatail.tsx
@@ -378,6 +378,15 @@ export default function ProfileDetails() {
             </span>
           </div>
           <Separator />
+          <div className="flex items-center justify-between rounded-lg">
+            <span className="font-medium text-gray-600 dark:text-gray-200">
+              Willing To Rebrand:
+            </span>
+            <span className="ml-2 rounded-lg border px-4 py-2 text-gray-600 dark:text-gray-200">
+              {profile?.willingToRebrand ? 'Yes' : 'No'}
+            </span>
+          </div>
+          <Separator />
           <div className="flex justify-between rounded-lg">
             <span className="font-medium text-gray-600 dark:text-gray-200">Risk Appetite:</span>
             <span className="ml-2">{getRiskLabel(profile?.financialSurvey?.riskAppetite)}</span>

--- a/frontend/components/ProfileFormComponents/ProfileForm.tsx
+++ b/frontend/components/ProfileFormComponents/ProfileForm.tsx
@@ -54,6 +54,7 @@ export default function ProfileForm({
       languages: [],
       additionalInformation: '',
       aboutMe: '',
+      willingToRebrand: false,
       personalityType: undefined,
       financialSurvey: {
         currentSalary: undefined,
@@ -109,6 +110,7 @@ export default function ProfileForm({
       phoneNumber: data.phoneNumber ?? '',
       additionalInformation: data.additionalInformation ?? '',
       aboutMe: data.aboutMe ?? '',
+      willingToRebrand: data.willingToRebrand ?? false,
       skills: data.skills ?? [],
       softSkills: data.softSkills ?? [],
       languages: data.languages ?? [],

--- a/frontend/lib/schemas/profileSchema.ts
+++ b/frontend/lib/schemas/profileSchema.ts
@@ -72,6 +72,7 @@ const baseProfileSchema = z.object({
   languages: z.array(languageEntrySchema).optional(),
   additionalInformation: z.string().optional(),
   aboutMe: z.string().optional(),
+  willingToRebrand: z.boolean().default(false),
   personalityType: z.nativeEnum(PersonalityType),
   financialSurvey: financialSurveySchema.optional(),
 });

--- a/frontend/lib/types/profile.ts
+++ b/frontend/lib/types/profile.ts
@@ -75,6 +75,7 @@ export type UserProfile = {
   languages?: LanguageEntry[];
   additionalInformation?: string;
   aboutMe?: string;
+  willingToRebrand?: boolean;
   personalityType: PersonalityType;
   financialSurvey?: FinancialSurvey;
 };


### PR DESCRIPTION
## Summary
- support `WillingToRebrand` in profile types and schema
- add form controls and default values for `WillingToRebrand`
- display `WillingToRebrand` on profile details

## Testing
- `npm run lint` *(fails: next not found)*
- `dotnet build VocareWebAPI/VocareWebAPI.csproj` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e78bde1008328bcb269edd037d2f4