### PR TITLE
Handle missing recommendations gracefully

### DIFF
--- a/frontend/components/AssistantComponents/MainPageAssisstant.tsx
+++ b/frontend/components/AssistantComponents/MainPageAssisstant.tsx
@@ -165,12 +165,36 @@ export default function AssistantPage() {
           setLoading(false);
           return;
         } catch (lastError: unknown) {
-          if (lastError instanceof AxiosError && lastError.response?.status !== 404) {
-            console.error('Something went wrong while getting last recommendations:', lastError);
-            setError(
-              lastError.response?.data?.detail ||
-                'Something went wrong while getting last recommendations.'
+          if (lastError instanceof AxiosError) {
+            const status = lastError.response?.status;
+            const detail =
+              lastError.response?.data?.detail || lastError.response?.data;
+
+            const notFound =
+              status === 404 ||
+              (status === 500 &&
+                typeof detail === 'string' &&
+                /no recommendation|nie znaleziono/i.test(detail));
+
+            if (!notFound) {
+              console.error(
+                'Something went wrong while getting last recommendations:',
+                lastError
+              );
+              setError(
+                typeof detail === 'string'
+                  ? detail
+                  : 'Something went wrong while getting last recommendations.'
+              );
+              setLoading(false);
+              return;
+            }
+          } else {
+            console.error(
+              'Unknown error while getting last recommendations:',
+              lastError
             );
+            setError('Unexpected error occurred');
             setLoading(false);
             return;
           }


### PR DESCRIPTION
## Summary
- update `MainPageAssisstant` to handle cases where `/last-recommendation` returns 500 or 404
- generate new recommendations if the last recommendation is missing

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ee93686e483289778168542a3e864