### PR TITLE
Add CV dashboard page

### DIFF
--- a/frontend/app/(root)/resume/ResumeComponent.tsx
+++ b/frontend/app/(root)/resume/ResumeComponent.tsx
@@ -23,7 +23,7 @@ import {
   Upload,
 } from 'lucide-react';
 import { createCv } from '@/lib/api/cv';
-import { CvDto } from '@/lib/types/cv';
+import { CvDto, CvDetailsDto } from '@/lib/types/cv';
 import { DatePickerWithCurrent } from './DatePickerWithCurrent';
 import { HoverCard, HoverCardContent, HoverCardTrigger } from '@/components/ui/hover-card';
 import html2canvas from 'html2canvas-pro';
@@ -94,7 +94,11 @@ interface PrivacyStatement {
   content: string;
 }
 
-const CVCreator: React.FC = () => {
+interface CVCreatorProps {
+  initialCv?: CvDetailsDto;
+}
+
+const CVCreator: React.FC<CVCreatorProps> = ({ initialCv }) => {
   const [personalInfo, setPersonalInfo] = useState<PersonalInfo>(() => {
     const saved = localStorage.getItem('personalInfo');
     return saved
@@ -522,6 +526,12 @@ const CVCreator: React.FC = () => {
       console.error('Failed to generate CV from profile', err);
     }
   };
+
+  useEffect(() => {
+    if (initialCv) {
+      populateFromCv(initialCv.cvData, initialCv.targetPosition || undefined);
+    }
+  }, [initialCv]);
 
   const downloadPDF = async () => {
     try {

--- a/frontend/app/(root)/resume/[id]/page.tsx
+++ b/frontend/app/(root)/resume/[id]/page.tsx
@@ -1,7 +1,45 @@
-import React from 'react';
+'use client';
 
-const page = () => {
-  return <div>page</div>;
+import React, { useEffect, useState } from 'react';
+import { useParams } from 'next/navigation';
+import Header from '@/components/SupportComponents/SectionsComponents/Header';
+import { GridBackgroundDemo } from '@/components/MarketComponents/GridBackgroundDemo';
+import CVCreator from '../ResumeComponent';
+import { getCvDetails } from '@/lib/api/cv';
+import { CvDetailsDto } from '@/lib/types/cv';
+
+const ResumeDetailPage = () => {
+  const params = useParams();
+  const id = typeof params.id === 'string' ? params.id : '';
+  const [cv, setCv] = useState<CvDetailsDto | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchCv = async () => {
+      if (!id) return;
+      try {
+        const data = await getCvDetails(id);
+        setCv(data);
+      } catch (err) {
+        console.error('Failed to load CV details', err);
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchCv();
+  }, [id]);
+
+  return (
+    <div className="font-poppins">
+      <Header />
+      <div className="relative">
+        <GridBackgroundDemo />
+        <div className="relative z-10 mx-auto max-w-6xl px-4 py-6">
+          {loading ? <p>Loading...</p> : cv && <CVCreator initialCv={cv} />}
+        </div>
+      </div>
+    </div>
+  );
 };
 
-export default page;
+export default ResumeDetailPage;

--- a/frontend/app/(root)/resume/page.tsx
+++ b/frontend/app/(root)/resume/page.tsx
@@ -1,18 +1,86 @@
 'use client';
 
-import React from 'react';
-import CVCreator from './ResumeComponent';
+import React, { useEffect, useState } from 'react';
+import Header from '@/components/SupportComponents/SectionsComponents/Header';
+import { GridBackgroundDemo } from '@/components/MarketComponents/GridBackgroundDemo';
+import { getUserCvs, getCvLimits } from '@/lib/api/cv';
+import { CvListItemDto, CvLimits } from '@/lib/types/cv';
+import Link from 'next/link';
+import Image from 'next/image';
 
-const page = () => {
+const ResumeDashboard = () => {
+  const [cvs, setCvs] = useState<CvListItemDto[]>([]);
+  const [limits, setLimits] = useState<CvLimits | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const [cvData, limitData] = await Promise.all([
+          getUserCvs(),
+          getCvLimits(),
+        ]);
+        setCvs(cvData);
+        setLimits(limitData);
+      } catch (err) {
+        console.error('Failed to load CV data', err);
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchData();
+  }, []);
+
   return (
-    <main>
-      {/* <div className="flex h-screen flex-col items-center justify-center">
-        <h1 className="text-4xl font-bold">In progress</h1>
-      </div> */}
-      {/* <ResumePage /> */}
-      <CVCreator />
-    </main>
+    <div className="font-poppins">
+      <Header />
+      <div className="relative">
+        <GridBackgroundDemo />
+        <div className="relative z-10 mx-auto max-w-6xl px-4 py-10">
+          <h1 className="mb-2 text-3xl font-bold">Your resumes</h1>
+          {limits && (
+            <p className="mb-6 text-gray-600 dark:text-gray-300">
+              {limits.currentCount} / {limits.maxLimit} used
+            </p>
+          )}
+          {loading ? (
+            <p>Loading...</p>
+          ) : (
+            <div className="grid gap-6 sm:grid-cols-2 md:grid-cols-3">
+              {cvs.map((cv) => (
+                <div
+                  key={cv.id}
+                  className="rounded-lg border bg-card p-4 shadow-sm"
+                >
+                  <div className="mb-3 h-40 w-full overflow-hidden rounded border bg-muted">
+                    <Image
+                      src="/svg/file.svg"
+                      alt={cv.name}
+                      width={300}
+                      height={160}
+                      className="h-full w-full object-cover p-4 invert-0 dark:invert"
+                    />
+                  </div>
+                  <h3 className="text-lg font-semibold">{cv.name}</h3>
+                  {cv.targetPosition && (
+                    <p className="text-sm text-gray-600 dark:text-gray-400">
+                      {cv.targetPosition}
+                    </p>
+                  )}
+                  <Link
+                    href={`/resume/${cv.id}`}
+                    className="mt-2 inline-block text-sm text-[#915EFF] hover:underline"
+                  >
+                    View
+                  </Link>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
   );
 };
 
-export default page;
+export default ResumeDashboard;

--- a/frontend/lib/api/cv.ts
+++ b/frontend/lib/api/cv.ts
@@ -1,5 +1,10 @@
 import { api } from '../api';
-import { CreateCvDto, CvDetailsDto } from '../types/cv';
+import {
+  CreateCvDto,
+  CvDetailsDto,
+  CvListItemDto,
+  CvLimits,
+} from '../types/cv';
 
 export const createCv = async (payload: CreateCvDto): Promise<CvDetailsDto> => {
   const { data } = await api.post('/api/cvs/create', payload);
@@ -8,5 +13,15 @@ export const createCv = async (payload: CreateCvDto): Promise<CvDetailsDto> => {
 
 export const getCvDetails = async (id: string): Promise<CvDetailsDto> => {
   const { data } = await api.get(`/api/cvs/details/${id}`);
+  return data;
+};
+
+export const getUserCvs = async (): Promise<CvListItemDto[]> => {
+  const { data } = await api.get('/api/cvs/my-cvs');
+  return data;
+};
+
+export const getCvLimits = async (): Promise<CvLimits> => {
+  const { data } = await api.get('/api/cvs/limits');
   return data;
 };

--- a/frontend/lib/types/cv.ts
+++ b/frontend/lib/types/cv.ts
@@ -59,6 +59,23 @@ export interface CvDetailsDto {
   notes?: string;
 }
 
+export interface CvListItemDto {
+  id: string;
+  name: string;
+  targetPosition?: string;
+  isDefault: boolean;
+  createdAt: string;
+  lastModifiedAt: string;
+  version: number;
+  notes?: string;
+}
+
+export interface CvLimits {
+  canCreateNew: boolean;
+  currentCount: number;
+  maxLimit: number;
+}
+
 export interface CreateCvDto {
   name: string;
   targetPosition?: string;


### PR DESCRIPTION
## Summary
- add functions for fetching CV list and limits
- extend CV type definitions
- implement `/resume` dashboard to list generated CVs and show subscription slots

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run format` *(fails: prettier plugin missing)*

------
https://chatgpt.com/codex/tasks/task_e_686587fb53288328ac4de1f8f63d7472