### PR TITLE
Add OTP dialog to forgot password

### DIFF
--- a/frontend/app/(auth)/forgot-password/page.tsx
+++ b/frontend/app/(auth)/forgot-password/page.tsx
@@ -14,10 +14,23 @@ import { useState } from 'react';
 import Image from 'next/image';
 import { ButtonForm } from '@/components/ui/button-form';
 import { ArrowRight } from 'lucide-react';
+import {
+  AlertDialog,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+import {
+  InputOTP,
+  InputOTPGroup,
+  InputOTPSlot,
+} from '@/components/ui/input-otp';
 import Link from 'next/link';
 
 const ForgotPasswordForm = () => {
   const [isLoading, setIsLoading] = useState(false);
+  const [openDialog, setOpenDialog] = useState(false);
 
   const form = useForm({
     defaultValues: {
@@ -29,6 +42,7 @@ const ForgotPasswordForm = () => {
     setIsLoading(true);
     console.log(values);
     setIsLoading(false);
+    setOpenDialog(true);
   };
 
   return (
@@ -50,7 +64,11 @@ const ForgotPasswordForm = () => {
             </FormItem>
           )}
         />
-        <ButtonForm type="submit" className="group form-button" disabled={isLoading}>
+        <ButtonForm
+          type="submit"
+          className="group form-button"
+          disabled={isLoading || !form.watch('email')}
+        >
           Reset Password
           <span className="arrow-animation">
             <ArrowRight />
@@ -76,6 +94,36 @@ const ForgotPasswordForm = () => {
         </div>
       </form>
     </Form>
+
+    <AlertDialog open={openDialog} onOpenChange={setOpenDialog}>
+      <AlertDialogContent className="font-poppins">
+        <AlertDialogHeader>
+          <AlertDialogTitle className="text-center">
+            Sprawdź e-mail
+          </AlertDialogTitle>
+          <AlertDialogDescription className="text-center">
+            Na adres{' '}
+            <span className="font-semibold text-[#915EFF]">
+              {form.getValues('email')}
+            </span>{' '}
+            został wysłany kod OTP. Wprowadź go poniżej.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+
+        <div className="mt-4 flex w-full justify-center">
+          <InputOTP maxLength={6} className="" containerClassName="" >
+            <InputOTPGroup>
+              <InputOTPSlot index={0} />
+              <InputOTPSlot index={1} />
+              <InputOTPSlot index={2} />
+              <InputOTPSlot index={3} />
+              <InputOTPSlot index={4} />
+              <InputOTPSlot index={5} />
+            </InputOTPGroup>
+          </InputOTP>
+        </div>
+      </AlertDialogContent>
+    </AlertDialog>
   );
 };
 


### PR DESCRIPTION
## Summary
- show OTP dialog after requesting reset password
- disable submit until email is filled
- use shadcn alert dialog and OTP input components

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm install` *(fails: 403 Forbidden - registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_68757a982550832883145a3d5093480a