### PR TITLE
Add Google OAuth login support

### DIFF
--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -6,6 +6,7 @@ import { Toaster } from '@/components/ui/sonner';
 
 import { TokenBalanceProvider } from '@/lib/contexts/TokenBalanceContext';
 // import SmoothScrollProvider from '@/components/SupportComponents/SmoothScrollProvider';
+import GoogleAuthHandler from '@/components/AuthComponents/GoogleAuthHandler';
 
 const sizmoPro = localFont({
   src: [
@@ -87,6 +88,7 @@ export default function RootLayout({
       <body className={`${sizmoPro.className} h-full antialiased selection:bg-[#915EFF]`}>
         {/* <SmoothScrollProvider> */}
         <TokenBalanceProvider>
+          <GoogleAuthHandler />
           <ThemeProvider attribute="class" defaultTheme="dark">
             {children}
             <Toaster />

--- a/frontend/components/AuthComponents/AuthForm.tsx
+++ b/frontend/components/AuthComponents/AuthForm.tsx
@@ -105,8 +105,10 @@ const AuthForm = ({ type }: { type: FormType }) => {
 
   // Funkcja do obsługi logowania przez Google
   const handleGoogleSignIn = () => {
+    const apiUrl = process.env.NEXT_PUBLIC_API_URL;
+    if (!apiUrl) return;
     // Przekierowanie na endpoint Google OAuth
-    window.location.href = 'http://localhost:8080/api/auth/google-signin';
+    window.location.href = `${apiUrl}/api/auth/google-signin`;
   };
 
   return (

--- a/frontend/components/AuthComponents/GoogleAuthHandler.tsx
+++ b/frontend/components/AuthComponents/GoogleAuthHandler.tsx
@@ -1,0 +1,60 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+
+const GoogleAuthHandler = () => {
+  const router = useRouter();
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+
+    const params = new URLSearchParams(window.location.search);
+    const googleLogin = params.get('googleLogin');
+    const userId = params.get('userId');
+
+    if (googleLogin === 'success' && userId) {
+      const fetchToken = async () => {
+        try {
+          const response = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/api/auth/google-get-token`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ userId }),
+          });
+
+          if (response.ok) {
+            let token: string | null = null;
+            const authHeader = response.headers.get('Authorization');
+            if (authHeader?.startsWith('Bearer ')) {
+              token = authHeader.replace('Bearer ', '');
+            } else {
+              try {
+                const data = await response.clone().json();
+                token = data.accessToken || data.token || null;
+              } catch {
+                // ignore json parse errors
+              }
+            }
+
+            if (token) {
+              localStorage.setItem('token', token);
+            }
+          }
+        } catch (err) {
+          console.error('Google auth token error', err);
+        } finally {
+          params.delete('googleLogin');
+          params.delete('userId');
+          const newUrl = `${window.location.pathname}${params.toString() ? '?' + params.toString() : ''}`;
+          router.replace(newUrl);
+        }
+      };
+
+      fetchToken();
+    }
+  }, [router]);
+
+  return null;
+};
+
+export default GoogleAuthHandler;

--- a/frontend/lib/auth.ts
+++ b/frontend/lib/auth.ts
@@ -33,10 +33,23 @@ export const registerUser = async ({ email, password }: RegisterInput) => {
 
 export const loginUser = async ({ email, password }: LoginInput) => {
   const response = await api.post(`/login`, { email, password });
-  const token = response.data.token;
+
+  // Try to retrieve token from common locations
+  let token: string | undefined =
+    response.data?.accessToken || response.data?.token;
+
+  // Fallback to Authorization header used by ASP.NET Identity
+  if (!token) {
+    const authHeader = response.headers['authorization'] as string | undefined;
+    if (authHeader?.startsWith('Bearer ')) {
+      token = authHeader.replace('Bearer ', '');
+    }
+  }
+
   if (token) {
     localStorage.setItem('token', token);
   }
+
   return response.data;
 };
 


### PR DESCRIPTION
## Summary
- support Google OAuth redirect logic in root layout with new `GoogleAuthHandler`
- fetch bearer token from `/api/auth/google-get-token`
- update AuthForm Google button to use API URL
- handle Authorization header in `loginUser`

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ebea7ad00832892cecac8a7a09f8e