### PR TITLE
Add Google OAuth flow on frontend

### DIFF
--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -3,6 +3,7 @@ import localFont from 'next/font/local';
 import './globals.css';
 import { ThemeProvider } from '@/components/ui/theme-provider';
 import { Toaster } from '@/components/ui/sonner';
+import GoogleOAuthHandler from '@/components/AuthComponents/GoogleOAuthHandler';
 
 import { TokenBalanceProvider } from '@/lib/contexts/TokenBalanceContext';
 // import SmoothScrollProvider from '@/components/SupportComponents/SmoothScrollProvider';
@@ -88,6 +89,7 @@ export default function RootLayout({
         {/* <SmoothScrollProvider> */}
         <TokenBalanceProvider>
           <ThemeProvider attribute="class" defaultTheme="dark">
+            <GoogleOAuthHandler />
             {children}
             <Toaster />
           </ThemeProvider>

--- a/frontend/components/AuthComponents/AuthForm.tsx
+++ b/frontend/components/AuthComponents/AuthForm.tsx
@@ -105,8 +105,12 @@ const AuthForm = ({ type }: { type: FormType }) => {
 
   // Funkcja do obsługi logowania przez Google
   const handleGoogleSignIn = () => {
-    // Przekierowanie na endpoint Google OAuth
-    window.location.href = 'http://localhost:8080/api/auth/google-signin';
+    const apiUrl = process.env.NEXT_PUBLIC_API_URL;
+    if (!apiUrl) {
+      toast.error('API url not configured');
+      return;
+    }
+    window.location.href = `${apiUrl}/api/auth/google-signin`;
   };
 
   return (

--- a/frontend/components/AuthComponents/GoogleOAuthHandler.tsx
+++ b/frontend/components/AuthComponents/GoogleOAuthHandler.tsx
@@ -1,0 +1,56 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
+import { toast } from 'sonner';
+
+const GoogleOAuthHandler = () => {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  useEffect(() => {
+    const googleLogin = searchParams.get('googleLogin');
+    const userId = searchParams.get('userId');
+
+    if (googleLogin === 'success' && userId) {
+      const fetchToken = async () => {
+        try {
+          const response = await fetch(
+            `${process.env.NEXT_PUBLIC_API_URL}/api/auth/google-get-token`,
+            {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({ userId }),
+              credentials: 'include',
+            }
+          );
+
+          if (!response.ok) {
+            throw new Error('Token request failed');
+          }
+
+          const authHeader = response.headers.get('Authorization');
+          const token = authHeader?.replace('Bearer ', '');
+
+          if (token) {
+            localStorage.setItem('token', token);
+            toast.success('Logged in with Google');
+          } else {
+            throw new Error('Token missing in response');
+          }
+        } catch (error) {
+          console.error('Google OAuth error:', error);
+          toast.error('Google login failed');
+        } finally {
+          router.replace('/');
+        }
+      };
+
+      fetchToken();
+    }
+  }, [searchParams, router]);
+
+  return null;
+};
+
+export default GoogleOAuthHandler;


### PR DESCRIPTION
## Summary
- add Google OAuth callback handler
- trigger OAuth handler from global layout
- use env variable for Google sign-in endpoint

## Testing
- `npm run lint` *(fails: next not found)*
- `dotnet test VocareWebAPI/VocareWebAPI.Tests.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687f88a949708328ad21bf97e5f36fd2