### PR TITLE
Fix Google OAuth callback path

### DIFF
--- a/VocareWebAPI/Program.cs
+++ b/VocareWebAPI/Program.cs
@@ -130,6 +130,7 @@ builder
     {
         options.ClientId = builder.Configuration["Authentication:Google:ClientId"]!;
         options.ClientSecret = builder.Configuration["Authentication:Google:ClientSecret"]!;
+        options.CallbackPath = "/api/auth/google-callback";
         options.SaveTokens = true;
         options.Events.OnRedirectToAuthorizationEndpoint = context =>
         {

--- a/VocareWebAPI/UserManagement/GOOGLE_OAUTH_INTEGRATION.md
+++ b/VocareWebAPI/UserManagement/GOOGLE_OAUTH_INTEGRATION.md
@@ -4,6 +4,16 @@
 
 Successfully integrated Google OAuth authentication to work with ASP.NET Core Identity Bearer tokens. This implementation allows users to authenticate via Google and receive bearer tokens for API access, just like regular email/password login.
 
+### Google Cloud Setup
+
+Add the following URL to the list of authorized OAuth redirect URIs in the Google Cloud console:
+
+```
+http://localhost:8080/api/auth/google-callback
+```
+
+This matches the callback path configured in `Program.cs`.
+
 ## Architecture
 
 ### 1. Authentication Schemes Configuration (Program.cs)


### PR DESCRIPTION
## Summary
- configure Google OAuth CallbackPath in the API
- document the redirect URI for Google Cloud setup

## Testing
- `dotnet build VocareWebAPI/VocareWebAPI.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687f8cc41b888328bfeab399696c4d0e