### PR TITLE
Add Google OAuth login flow

### DIFF
--- a/frontend/.env.production
+++ b/frontend/.env.production
@@ -1,2 +1,4 @@
 
 NEXT_PUBLIC_API_URL=https://vocare-production-e568.up.railway.app
+NEXT_PUBLIC_GOOGLE_CLIENT_ID=your-google-client-id
+NEXT_PUBLIC_GOOGLE_REDIRECT_URI=https://your-app.com/google-callback

--- a/frontend/app/google-callback/page.tsx
+++ b/frontend/app/google-callback/page.tsx
@@ -1,0 +1,35 @@
+'use client';
+import { useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import { verifyGoogleToken } from '@/lib/auth';
+import { toast } from 'sonner';
+
+const GoogleCallback = () => {
+  const router = useRouter();
+
+  useEffect(() => {
+    const hash = window.location.hash.startsWith('#')
+      ? window.location.hash.substring(1)
+      : '';
+    const params = new URLSearchParams(hash);
+    const token = params.get('access_token');
+    if (!token) {
+      toast.error('Google login failed');
+      router.replace('/sign-in');
+      return;
+    }
+    verifyGoogleToken(token)
+      .then(() => {
+        toast.success('Login successful');
+        router.replace('/');
+      })
+      .catch(() => {
+        toast.error('Google login failed');
+        router.replace('/sign-in');
+      });
+  }, [router]);
+
+  return <p className="p-4">Processing Google login...</p>;
+};
+
+export default GoogleCallback;

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -3,6 +3,7 @@ import localFont from 'next/font/local';
 import './globals.css';
 import { ThemeProvider } from '@/components/ui/theme-provider';
 import { Toaster } from '@/components/ui/sonner';
+import { GoogleOAuthProvider } from '@react-oauth/google';
 
 import { TokenBalanceProvider } from '@/lib/contexts/TokenBalanceContext';
 // import SmoothScrollProvider from '@/components/SupportComponents/SmoothScrollProvider';
@@ -82,16 +83,22 @@ export default function RootLayout({
 }: Readonly<{
   children: React.ReactNode;
 }>) {
+  const googleClientId = process.env.NEXT_PUBLIC_GOOGLE_CLIENT_ID!;
+  if (!googleClientId) {
+    throw new Error('NEXT_PUBLIC_GOOGLE_CLIENT_ID not set');
+  }
   return (
     <html lang="en" suppressHydrationWarning className="">
       <body className={`${sizmoPro.className} h-full antialiased selection:bg-[#915EFF]`}>
         {/* <SmoothScrollProvider> */}
-        <TokenBalanceProvider>
-          <ThemeProvider attribute="class" defaultTheme="dark">
-            {children}
-            <Toaster />
-          </ThemeProvider>
-        </TokenBalanceProvider>
+        <GoogleOAuthProvider clientId={googleClientId}>
+          <TokenBalanceProvider>
+            <ThemeProvider attribute="class" defaultTheme="dark">
+              {children}
+              <Toaster />
+            </ThemeProvider>
+          </TokenBalanceProvider>
+        </GoogleOAuthProvider>
         {/* </SmoothScrollProvider> */}
       </body>
     </html>

--- a/frontend/components/AuthComponents/AuthForm.tsx
+++ b/frontend/components/AuthComponents/AuthForm.tsx
@@ -5,7 +5,7 @@ import { useForm } from 'react-hook-form';
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { authFormSchema, AuthFormType } from '@/lib/schemas/authSchema';
-import { registerUser, loginUser } from '@/lib/auth';
+import { registerUser, loginUser, verifyGoogleToken } from '@/lib/auth';
 import {
   Form,
   FormControl,
@@ -23,12 +23,23 @@ import { ButtonForm } from '../ui/button-form';
 import { AxiosError } from 'axios';
 import OAuthButton from './OAuthButton';
 import { google } from '@/app/constants';
+import { useGoogleLogin } from '@react-oauth/google';
 
 type FormType = 'sign-in' | 'sign-up';
 
 const AuthForm = ({ type }: { type: FormType }) => {
   const [isLoading, setIsLoading] = useState(false);
   const router = useRouter();
+
+  const googleLogin = useGoogleLogin({
+    scope: 'openid profile email',
+    ux_mode: 'redirect',
+    redirect_uri:
+      process.env.NEXT_PUBLIC_GOOGLE_REDIRECT_URI ||
+      `${window.location.origin}/google-callback`,
+    flow: 'implicit',
+    onError: () => toast.error('Google login failed'),
+  });
 
   const formSchema = authFormSchema(type);
   const form = useForm<AuthFormType>({
@@ -220,9 +231,10 @@ const AuthForm = ({ type }: { type: FormType }) => {
             </div>
 
             <div className="tems-center mt-4 flex w-full flex-row justify-center gap-2">
-              <OAuthButton 
-                icon={google} 
-                label="Login with Google" 
+              <OAuthButton
+                icon={google}
+                label="Login with Google"
+                onClick={() => googleLogin()}
               />
               {/* <OAuthButton icon={facebook} label="Login with Facebook" onClick={handleFacebookSignIn} /> */}
             </div>

--- a/frontend/lib/auth.ts
+++ b/frontend/lib/auth.ts
@@ -40,6 +40,16 @@ export const loginUser = async ({ email, password }: LoginInput) => {
   return response.data;
 };
 
+export const verifyGoogleToken = async (accessToken: string) => {
+  const response = await api.post(`/auth/google-verify`, { accessToken });
+  const authHeader = response.headers['authorization'] as string | undefined;
+  if (authHeader?.startsWith('Bearer ')) {
+    const token = authHeader.slice('Bearer '.length);
+    localStorage.setItem('token', token);
+  }
+  return response.data;
+};
+
 export const logoutUser = async () => {
   try {
     await api.post(`${AUTH_PREFIX}/logout`);

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -5,6 +5,8 @@ const nextConfig: NextConfig = {
   reactStrictMode: true,
   env: {
     NEXT_PUBLIC_API_URL: process.env.NEXT_PUBLIC_API_URL!,
+    NEXT_PUBLIC_GOOGLE_CLIENT_ID: process.env.NEXT_PUBLIC_GOOGLE_CLIENT_ID!,
+    NEXT_PUBLIC_GOOGLE_REDIRECT_URI: process.env.NEXT_PUBLIC_GOOGLE_REDIRECT_URI!,
   },
   images: {
     remotePatterns: [

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -63,6 +63,7 @@
     "react-just-parallax": "^3.1.16",
     "react-scroll-parallax": "^3.4.5",
     "react-to-pdf": "^2.0.0",
+    "@react-oauth/google": "^0.8.0",
     "recharts": "^2.15.2",
     "sonner": "^2.0.1",
     "tailwind-merge": "^3.0.2",


### PR DESCRIPTION
## Summary
- add `@react-oauth/google` package
- configure env vars in Next config and `.env.production`
- wrap app with `GoogleOAuthProvider`
- implement Google token verification helper
- create Google callback page
- wire Google login button to start OAuth flow

## Testing
- `npm run format` *(fails: Cannot find package 'prettier-plugin-tailwindcss')*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_687fc242c3888328b1ef95ca1180ff5e