### PR TITLE
Fix Google login options

### DIFF
--- a/frontend/components/AuthComponents/AuthForm.tsx
+++ b/frontend/components/AuthComponents/AuthForm.tsx
@@ -5,7 +5,7 @@ import { useForm } from 'react-hook-form';
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { authFormSchema, AuthFormType } from '@/lib/schemas/authSchema';
-import { registerUser, loginUser, verifyGoogleToken } from '@/lib/auth';
+import { registerUser, loginUser } from '@/lib/auth';
 import {
   Form,
   FormControl,
@@ -33,7 +33,6 @@ const AuthForm = ({ type }: { type: FormType }) => {
 
   const googleLogin = useGoogleLogin({
     scope: 'openid profile email',
-    ux_mode: 'redirect',
     redirect_uri:
       process.env.NEXT_PUBLIC_GOOGLE_REDIRECT_URI ||
       `${window.location.origin}/google-callback`,


### PR DESCRIPTION
## Summary
- remove unused `verifyGoogleToken` import
- adjust `useGoogleLogin` options to satisfy TS types

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_687fdbabe3b08328a104a0a4500684a1