### PR TITLE
Fix Google OAuth frontend flow

### DIFF
--- a/frontend/components/AuthComponents/AuthForm.tsx
+++ b/frontend/components/AuthComponents/AuthForm.tsx
@@ -31,20 +31,8 @@ const AuthForm = ({ type }: { type: FormType }) => {
   const router = useRouter();
 
 const handleGoogleRedirect = () => {
-  const clientId = process.env.NEXT_PUBLIC_GOOGLE_CLIENT_ID!;
-  const redirectUri = process.env.NEXT_PUBLIC_GOOGLE_REDIRECT_URI!;
-  
-  console.log('Client ID:', clientId);
-  console.log('Redirect URI:', redirectUri);
-
-  const googleUrl = `https://accounts.google.com/o/oauth2/v2/auth?` +
-  `client_id=${clientId}&` +
-  `redirect_uri=${encodeURIComponent(redirectUri)}&` +
-  `response_type=code&` +
-  `scope=openid%20email%20profile`;
-
-  console.log('Final Google URL:', googleUrl);
-  window.location.href = googleUrl;
+  const apiUrl = process.env.NEXT_PUBLIC_API_URL!;
+  window.location.href = `${apiUrl}/api/Auth/google-signin`;
 };
 
   const formSchema = authFormSchema(type);


### PR DESCRIPTION
## Summary
- align Google login button with backend OAuth endpoint
- update Google callback page to use `userId` from callback and store bearer token

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm run lint` *(fails: next not found)*
- `dotnet build VocareWebAPI/VocareWebAPI.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688094fe61688328aded145d2158178b