### PR TITLE
Enable Google OAuth login

### DIFF
--- a/frontend/.env.local.example
+++ b/frontend/.env.local.example
@@ -1,0 +1,2 @@
+NEXT_PUBLIC_API_URL=http://localhost:8080
+NEXT_PUBLIC_GOOGLE_CLIENT_ID=your-google-client-id

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -14,6 +14,13 @@ pnpm dev
 bun dev
 ```
 
+Create a `.env.local` file with the following variables to configure API access and Google OAuth:
+
+```env
+NEXT_PUBLIC_API_URL=http://localhost:8080
+NEXT_PUBLIC_GOOGLE_CLIENT_ID=your-google-client-id
+```
+
 Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
 
 You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.

--- a/frontend/lib/auth.ts
+++ b/frontend/lib/auth.ts
@@ -50,3 +50,17 @@ export const logoutUser = async () => {
     window.location.href = '/sign-in';
   }
 };
+
+export const googleVerify = async (accessToken: string) => {
+  const response = await api.post('/api/Auth/google-verify', { accessToken });
+  const token =
+    response.data.token ||
+    response.data.accessToken ||
+    response.headers['authorization']?.replace('Bearer ', '');
+
+  if (token) {
+    localStorage.setItem('token', token);
+  }
+
+  return response.data;
+};


### PR DESCRIPTION
## Summary
- add env example file with Google OAuth client id
- document required environment variables in README
- extend auth library with `googleVerify`
- load Google OAuth script and handle login in AuthForm

## Testing
- `npm run format` *(fails: Cannot find package 'prettier-plugin-tailwindcss')*

------
https://chatgpt.com/codex/tasks/task_e_6880ea38bc1c8328bca8451ca31d3767