### PR TITLE
Add frontend password reset flow

### DIFF
--- a/frontend/app/(auth)/forgot-password/page.tsx
+++ b/frontend/app/(auth)/forgot-password/page.tsx
@@ -14,6 +14,8 @@ import { useState } from 'react';
 import Image from 'next/image';
 import { ButtonForm } from '@/components/ui/button-form';
 import { ArrowRight } from 'lucide-react';
+import { forgotPassword } from '@/lib/auth';
+import { toast } from 'sonner';
 import {
   AlertDialog,
   AlertDialogContent,
@@ -41,14 +43,19 @@ const ForgotPasswordForm = () => {
 
   const onSubmit = async (values: { email: string }) => {
     setIsLoading(true);
-    console.log(values);
-    setIsLoading(false);
-    setOpenDialog(true);
+    try {
+      await forgotPassword(values.email);
+      toast.success('If the email is registered, a reset link will be sent.');
+      setOpenDialog(true);
+    } catch (error) {
+      toast.error('Failed to send reset email');
+    } finally {
+      setIsLoading(false);
+    }
   };
 
   const handleResendEmail = () => {
-    // Logic to resend email
-    console.log('Resending email to:', form.getValues('email'));
+    forgotPassword(form.getValues('email'));
   };
 
   return (

--- a/frontend/app/(auth)/reset-password/page.tsx
+++ b/frontend/app/(auth)/reset-password/page.tsx
@@ -1,0 +1,127 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useSearchParams, useRouter } from 'next/navigation';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import {
+  Form,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormControl,
+  FormMessage,
+} from '@/components/ui/form';
+import { Input } from '@/components/ui/input';
+import { ButtonForm } from '@/components/ui/button-form';
+import { ArrowRight } from 'lucide-react';
+import { toast } from 'sonner';
+import { resetPassword, validateResetToken } from '@/lib/auth';
+import {
+  resetPasswordSchema,
+  type ResetPasswordForm,
+} from '@/lib/schemas/resetPasswordSchema';
+import Image from 'next/image';
+
+const ResetPasswordPage = () => {
+  const searchParams = useSearchParams();
+  const router = useRouter();
+  const token = searchParams.get('token') ?? '';
+  const email = searchParams.get('email') ?? '';
+  const [checking, setChecking] = useState(true);
+  const [tokenValid, setTokenValid] = useState(false);
+  const form = useForm<ResetPasswordForm>({
+    resolver: zodResolver(resetPasswordSchema),
+    defaultValues: { password: '', confirmPassword: '' },
+  });
+
+  useEffect(() => {
+    const validate = async () => {
+      try {
+        await validateResetToken(token, email);
+        setTokenValid(true);
+      } catch {
+        toast.error('Invalid or expired token');
+      } finally {
+        setChecking(false);
+      }
+    };
+    if (token && email) validate();
+    else setChecking(false);
+  }, [token, email]);
+
+  const onSubmit = async (values: ResetPasswordForm) => {
+    try {
+      await resetPassword({
+        email,
+        token,
+        newPassword: values.password,
+        confirmPassword: values.confirmPassword,
+      });
+      toast.success('Password reset successfully');
+      router.push('/sign-in');
+    } catch {
+      toast.error('Failed to reset password');
+    }
+  };
+
+  if (checking) {
+    return (
+      <div className="flex h-full items-center justify-center">
+        <Image
+          src="/assets/icons/loader.svg"
+          alt="loader"
+          width={24}
+          height={24}
+          className="animate-spin"
+        />
+      </div>
+    );
+  }
+
+  if (!tokenValid) {
+    return <p className="error-message">Token is invalid or expired.</p>;
+  }
+
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)} className="auth-form">
+        <h1 className="form-title">Set New Password</h1>
+        <FormField
+          control={form.control}
+          name="password"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Password</FormLabel>
+              <FormControl>
+                <Input type="password" className="input-profile" {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <FormField
+          control={form.control}
+          name="confirmPassword"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Confirm Password</FormLabel>
+              <FormControl>
+                <Input type="password" className="input-profile" {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <ButtonForm type="submit" className="group form-button">
+          Reset Password
+          <span className="arrow-animation">
+            <ArrowRight />
+          </span>
+        </ButtonForm>
+      </form>
+    </Form>
+  );
+};
+
+export default ResetPasswordPage;

--- a/frontend/lib/auth.ts
+++ b/frontend/lib/auth.ts
@@ -42,3 +42,27 @@ export const logoutUser = () => {
   localStorage.removeItem('token');
   window.location.href = '/sign-in';
 };
+
+export const forgotPassword = async (email: string) => {
+  const { data } = await api.post('/api/auth/forgot-password', { email });
+  return data;
+};
+
+interface ResetPasswordInput {
+  email: string;
+  token: string;
+  newPassword: string;
+  confirmPassword: string;
+}
+
+export const resetPassword = async (payload: ResetPasswordInput) => {
+  const { data } = await api.post('/api/auth/reset-password', payload);
+  return data;
+};
+
+export const validateResetToken = async (token: string, email: string) => {
+  const { data } = await api.get('/api/auth/validate-reset-token', {
+    params: { token, email },
+  });
+  return data;
+};

--- a/frontend/lib/schemas/resetPasswordSchema.ts
+++ b/frontend/lib/schemas/resetPasswordSchema.ts
@@ -1,0 +1,18 @@
+import { z } from 'zod';
+
+export const resetPasswordSchema = z
+  .object({
+    password: z.string().min(6, 'Password must be at least 6 characters'),
+    confirmPassword: z.string().min(6, 'Password must be at least 6 characters'),
+  })
+  .superRefine((data, ctx) => {
+    if (data.password !== data.confirmPassword) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'Passwords do not match',
+        path: ['confirmPassword'],
+      });
+    }
+  });
+
+export type ResetPasswordForm = z.infer<typeof resetPasswordSchema>;


### PR DESCRIPTION
## Summary
- implement API calls for forgot and reset password
- add schema for reset password form validation
- update forgot password page to call backend
- add reset password page with token validation

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm install` *(fails: 403 Forbidden fetching packages)*

------
https://chatgpt.com/codex/tasks/task_e_6887dd1354648328b66a05e46055ca15