### PR TITLE
Implement password reset pages

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -34,3 +34,7 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+
+## Password reset
+
+Users can request a password reset via `/forgot-password`. After receiving the e-mail link they will be redirected to `/reset-password` with the provided token and can set a new password.

--- a/frontend/app/(auth)/reset-password/page.tsx
+++ b/frontend/app/(auth)/reset-password/page.tsx
@@ -1,0 +1,141 @@
+'use client';
+
+import { useSearchParams, useRouter } from 'next/navigation';
+import { useEffect, useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import {
+  resetPasswordSchema,
+  ResetPasswordFormType,
+} from '@/lib/schemas/passwordSchema';
+import { resetPassword, validateResetToken } from '@/lib/auth';
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/components/ui/form';
+import { Input } from '@/components/ui/input';
+import { ButtonForm } from '@/components/ui/button-form';
+import { ArrowRight } from 'lucide-react';
+import Image from 'next/image';
+import { toast } from 'sonner';
+import Link from 'next/link';
+
+const ResetPasswordPage = () => {
+  const searchParams = useSearchParams();
+  const router = useRouter();
+  const token = searchParams.get('token') || '';
+  const email = searchParams.get('email') || '';
+
+  const [isValid, setIsValid] = useState<boolean | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+
+  const form = useForm<ResetPasswordFormType>({
+    resolver: zodResolver(resetPasswordSchema),
+    defaultValues: {
+      email,
+      token,
+      newPassword: '',
+      confirmPassword: '',
+    },
+  });
+
+  useEffect(() => {
+    if (!token || !email) return setIsValid(false);
+    const validate = async () => {
+      try {
+        const { isValid } = await validateResetToken(token, email);
+        setIsValid(isValid);
+        if (!isValid) toast.error('Invalid or expired token');
+      } catch (err) {
+        console.error(err);
+        toast.error('Invalid or expired token');
+        setIsValid(false);
+      }
+    };
+    validate();
+  }, [token, email]);
+
+  const onSubmit = async (values: ResetPasswordFormType) => {
+    setIsLoading(true);
+    try {
+      await resetPassword(values);
+      toast.success('Password reset successfully');
+      router.push('/sign-in');
+    } catch (err) {
+      console.error(err);
+      toast.error('Failed to reset password');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  if (isValid === false) {
+    return (
+      <div className="flex flex-col items-center justify-center">
+        <p className="mb-4 text-center text-red-500">Invalid or expired token.</p>
+        <Link href="/forgot-password" className="text-[#915EFF] underline">
+          Request new link
+        </Link>
+      </div>
+    );
+  }
+
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)} className="auth-form">
+        <h1 className="form-title">Set New Password</h1>
+        <FormField
+          control={form.control}
+          name="newPassword"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel className="shad-form-label">New Password</FormLabel>
+              <FormControl>
+                <Input type="password" className="input-profile" {...field} />
+              </FormControl>
+              <FormMessage className="shad-form-message" />
+            </FormItem>
+          )}
+        />
+        <FormField
+          control={form.control}
+          name="confirmPassword"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel className="shad-form-label">Confirm Password</FormLabel>
+              <FormControl>
+                <Input type="password" className="input-profile" {...field} />
+              </FormControl>
+              <FormMessage className="shad-form-message" />
+            </FormItem>
+          )}
+        />
+        <ButtonForm
+          type="submit"
+          className="group form-button"
+          disabled={isLoading}
+        >
+          Reset Password
+          <span className="arrow-animation">
+            <ArrowRight />
+          </span>
+          {isLoading && (
+            <Image
+              src="/assets/icons/loader.svg"
+              alt="loader"
+              width={24}
+              height={24}
+              className="ml-2 animate-spin"
+            />
+          )}
+        </ButtonForm>
+      </form>
+    </Form>
+  );
+};
+
+export default ResetPasswordPage;

--- a/frontend/lib/auth.ts
+++ b/frontend/lib/auth.ts
@@ -64,3 +64,27 @@ export const googleVerify = async (accessToken: string) => {
 
   return response.data;
 };
+
+export const requestPasswordReset = async (email: string) => {
+  const { data } = await api.post(`${AUTH_PREFIX}/forgot-password`, { email });
+  return data;
+};
+
+interface ResetPasswordInput {
+  email: string;
+  token: string;
+  newPassword: string;
+  confirmPassword: string;
+}
+
+export const resetPassword = async (payload: ResetPasswordInput) => {
+  const { data } = await api.post(`${AUTH_PREFIX}/reset-password`, payload);
+  return data;
+};
+
+export const validateResetToken = async (token: string, email: string) => {
+  const { data } = await api.get(`${AUTH_PREFIX}/validate-reset-token`, {
+    params: { token, email },
+  });
+  return data;
+};

--- a/frontend/lib/schemas/passwordSchema.ts
+++ b/frontend/lib/schemas/passwordSchema.ts
@@ -1,0 +1,25 @@
+import { z } from 'zod';
+
+export const forgotPasswordSchema = z.object({
+  email: z.string().email(),
+});
+
+export const resetPasswordSchema = z
+  .object({
+    email: z.string().email(),
+    token: z.string().min(1),
+    newPassword: z.string().min(6, 'Password must be at least 6 characters'),
+    confirmPassword: z.string().min(6, 'Password must be at least 6 characters'),
+  })
+  .superRefine((data, ctx) => {
+    if (data.newPassword !== data.confirmPassword) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'Passwords do not match',
+        path: ['confirmPassword'],
+      });
+    }
+  });
+
+export type ForgotPasswordFormType = z.infer<typeof forgotPasswordSchema>;
+export type ResetPasswordFormType = z.infer<typeof resetPasswordSchema>;


### PR DESCRIPTION
## Summary
- implement reset password logic in auth API
- add schemas for forgot/reset password forms
- update forgot password page with backend integration
- add reset password page
- document password reset flow in README

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6887e3ef12e48328821d092d07c42bbf