### PR TITLE
Refactor resume layout and CSS for stable page breaks

### DIFF
--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -588,141 +588,51 @@ input:-webkit-autofill {
   -webkit-text-fill-color: #f9f5ee !important;
 }
 
-/* 1. Prevent word breaking across lines and pages */
-.cv-content {
-  /* Prevent hyphenation */
-  hyphens: none;
-  -webkit-hyphens: none;
-  -moz-hyphens: none;
-  
-  /* Prevent word breaking */
-  word-break: keep-all;
-  overflow-wrap: normal;
-  
-  /* Better line breaking for long words */
-  word-wrap: break-word;
-  
-  /* Ensure proper text rendering */
+/* CV content layout */
+.cv-content,
+.cv-content .text-break-safe {
+  word-break: normal;
+  overflow-wrap: anywhere;
+  hyphens: auto;
+  line-height: 1.45;
   text-rendering: optimizeLegibility;
 }
 
-/* 2. Specific rules for text elements to prevent cutting */
-.cv-content p,
-.cv-content div,
-.cv-content span {
-  /* Prevent orphans and widows */
-  orphans: 2;
-  widows: 2;
-  
-  /* Avoid breaking inside elements */
+.cv-content [data-section] {
   break-inside: avoid;
   page-break-inside: avoid;
-  
-  /* Better line height for readability */
-  line-height: 1.4;
 }
 
-/* 3. Special handling for headings */
-.cv-content h1,
-.cv-content h2,
-.cv-content h3,
-.cv-content h4 {
-  /* Prevent breaking after headings */
+.cv-content [data-section] h3 {
   break-after: avoid;
   page-break-after: avoid;
-  
-  /* Keep with next element */
-  keep-with-next: always;
-  
-  /* Prevent breaking inside headings */
-  break-inside: avoid;
-  page-break-inside: avoid;
-  
-  /* Better spacing */
-  margin-bottom: 0.5em;
+  margin-bottom: 8px;
 }
 
-/* 4. Specific rules for experience and education items */
 .exp-item,
 .edu-item {
-  /* Keep entire items together */
   break-inside: avoid !important;
   page-break-inside: avoid !important;
-  
-  /* Minimum space required */
-  orphans: 3;
-  widows: 3;
-  
-  /* Margin to prevent tight spacing */
   margin-bottom: 1em;
-}
-
-/* 5. Handle long descriptions */
-.exp-desc,
-.edu-desc {
-  /* Allow breaking but with constraints */
   orphans: 2;
   widows: 2;
-  
-  /* Better line spacing */
-  line-height: 1.5;
-  
-  /* Prevent aggressive word breaking */
-  word-break: normal;
-  overflow-wrap: break-word;
 }
 
-/* 6. Skills and tags - prevent breaking */
+.exp-desc,
+.edu-desc,
+.text-break-safe {
+  line-height: 1.5;
+}
+
 .skill-tag,
 .language-tag,
 .hobby-tag {
-  /* Keep tags intact */
   break-inside: avoid !important;
   page-break-inside: avoid !important;
   white-space: nowrap;
 }
 
-/* 7. Contact information */
-.contact-info {
-  /* Keep contact items together */
-  break-inside: avoid;
-  page-break-inside: avoid;
-  
-  /* Prevent text overflow */
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
-/* 8. Page-specific rules */
-@media print {
-  .cv-content {
-    /* Print-specific rules */
-    print-color-adjust: exact;
-    
-    /* Better page breaks */
-    page-break-inside: avoid;
-  }
-  
-  /* Ensure sections stay together on print */
-  .cv-content [data-section] {
-    break-inside: avoid-page;
-    page-break-inside: avoid;
-  }
-}
-
-/* 9. Responsive text sizing to prevent overflow */
-@media screen and (max-width: 210mm) {
-  .cv-content {
-    font-size: 0.9em;
-    line-height: 1.3;
-  }
-}
-
-/* 10. Emergency fallback for very long words */
-.cv-content .break-long-words {
+.break-long-words {
   word-break: break-all;
   overflow-wrap: anywhere;
-  hyphens: auto;
-  -webkit-hyphens: auto;
-  -moz-hyphens: auto;
 }


### PR DESCRIPTION
## Summary
- replace inline style injection with centralized global CSS
- compute CV page height dynamically and adjust break logic
- mark profile section and update A4 frame dimensions

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: existing lint errors in repository)*
- `npx eslint app/(root)/resume/ResumeComponent.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68a89a0691ac832882d7b311be0e2217