### PR TITLE
feat: add MarketNewsBackgroundService for scheduled news generation

### DIFF
--- a/VocareWebAPI/Extensions/ServiceCollectionExtensions/DependencyInjectionExtensions.cs
+++ b/VocareWebAPI/Extensions/ServiceCollectionExtensions/DependencyInjectionExtensions.cs
@@ -10,6 +10,7 @@ using VocareWebAPI.CvGenerator.Services.Implementations;
 using VocareWebAPI.CvGenerator.Services.Interfaces;
 using VocareWebAPI.MarketNews.Repositories.Implementations;
 using VocareWebAPI.MarketNews.Repositories.Interfaces;
+using VocareWebAPI.MarketNews.services.Implementations;
 using VocareWebAPI.MarketNews.Services.Implementations;
 using VocareWebAPI.MarketNews.Services.Interfaces;
 using VocareWebAPI.Repositories;
@@ -50,6 +51,8 @@ namespace VocareWebAPI.Extensions.ServiceCollectionExtensions
             // Other services
             services.AddScoped<IEmailService, EmailService>();
             services.AddScoped<IMarketNewsService, MarketNewsService>();
+
+            services.AddHostedService<MarketNewsBackgroundService>();
 
             return services;
         }

--- a/VocareWebAPI/MarketNews/services/Implementations/MarketNewsBackgroundService.cs
+++ b/VocareWebAPI/MarketNews/services/Implementations/MarketNewsBackgroundService.cs
@@ -1,0 +1,78 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using VocareWebAPI.MarketNews.Services.Interfaces;
+
+namespace VocareWebAPI.MarketNews.services.Implementations
+{
+    public class MarketNewsBackgroundService : BackgroundService
+    {
+        private readonly IServiceProvider _serviceProvider;
+        private readonly ILogger<MarketNewsBackgroundService> _logger;
+
+        public MarketNewsBackgroundService(
+            IServiceProvider serviceProvider,
+            ILogger<MarketNewsBackgroundService> logger
+        )
+        {
+            _serviceProvider = serviceProvider;
+            _logger = logger;
+        }
+
+        protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+        {
+            // Oblicz kiedy ma być następne generowanie (np. każdy poniedziałek o 6:00)
+            var nextRun = GetNextSunday6AM();
+
+            while (!stoppingToken.IsCancellationRequested)
+            {
+                var delay = nextRun - DateTime.UtcNow;
+
+                if (delay > TimeSpan.Zero)
+                {
+                    _logger.LogInformation(
+                        "Next news generation scheduled for: {NextRun}",
+                        nextRun
+                    );
+                    await Task.Delay(delay, stoppingToken);
+                }
+
+                try
+                {
+                    using var scope = _serviceProvider.CreateScope();
+                    var marketNewsService =
+                        scope.ServiceProvider.GetRequiredService<IMarketNewsService>();
+
+                    var generated = await marketNewsService.GenerateWeeklyNewsAsync();
+
+                    if (generated)
+                        _logger.LogInformation(
+                            "Weekly news generated successfully at {Time}",
+                            DateTime.UtcNow
+                        );
+                    else
+                        _logger.LogInformation("News already exists for today");
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Error generating weekly news");
+                }
+
+                // Ustaw następne wykonanie
+                nextRun = GetNextSunday6AM();
+            }
+        }
+
+        private DateTime GetNextSunday6AM()
+        {
+            var now = DateTime.UtcNow;
+            var daysUntilSunday = ((int)DayOfWeek.Sunday - (int)now.DayOfWeek + 7) % 7;
+
+            if (daysUntilSunday == 0 && now.Hour >= 6)
+                daysUntilSunday = 7;
+
+            return now.Date.AddDays(daysUntilSunday).AddHours(6);
+        }
+    }
+}


### PR DESCRIPTION
This pull request introduces a background service that automates the weekly generation of market news. The main change is the addition of `MarketNewsBackgroundService`, which schedules and triggers the news generation process every Sunday at 6:00 AM UTC. The service is registered as a hosted service, ensuring it runs continuously in the application's background.

**Background service for scheduled market news generation:**

* Added new class `MarketNewsBackgroundService` in `VocareWebAPI/MarketNews/services/Implementations/MarketNewsBackgroundService.cs`, which runs as a background service and triggers weekly news generation every Sunday at 6:00 AM UTC. It uses dependency injection to access `IMarketNewsService` and logs the status and errors of the generation process.

**Dependency injection updates:**

* Registered `MarketNewsBackgroundService` as a hosted service in the dependency injection container via `AddHostedService<MarketNewsBackgroundService>()` in `DependencyInjectionExtensions.cs`, ensuring it starts with the application.
* Added the necessary using statement for `MarketNewsBackgroundService` in `DependencyInjectionExtensions.cs` to support its registration.